### PR TITLE
Redirect error messages to stderr and use proper exit code

### DIFF
--- a/data/extra.sh
+++ b/data/extra.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e
 if [ ! -f /tmp/grml-plus/devicename ]; then
-	echo "run make-grml-plus first!"
-	exit -1
+	echo "run make-grml-plus first!" >&2
+	exit 1
 fi
 . /tmp/grml-plus/devicename
 echo "Mounting $DEVICE to /tmp/grml-plus/mnt."

--- a/data/run-debian-installer.sh
+++ b/data/run-debian-installer.sh
@@ -3,8 +3,8 @@
 set -e
 
 if [ ! -f "$1" ]; then
-	echo "Usage: ./run-debian-installer debian-isofile.iso"
-	exit -1
+	echo "Usage: ./run-debian-installer debian-isofile.iso" >&2
+	exit 1
 fi
 
 mkdir -p /tmp/debinst/cdrom

--- a/make-grml-plus
+++ b/make-grml-plus
@@ -8,26 +8,26 @@ echo "============================="
 set -e
 
 if [ -z "$1" ]; then
-	echo "Usage: ./make-grml-plus [device]"
-	exit -1
+	echo "Usage: ./make-grml-plus [device]" >&2
+	exit 1
 fi
 
 DEVICE=$1
 MBR=`echo $1 | sed 's/[0-9]//g'`
 
 if [ ! -b $DEVICE -o ! -b $MBR ]; then
-	echo "Error: Either $DEVICE or $MBR is not a valid block device."
-	exit -1
+	echo "Error: Either $DEVICE or $MBR is not a valid block device." >&2
+	exit 1
 fi
 
 if [ ! "`grub-probe -d $DEVICE -t fs`" == "fat" ]; then
-	echo "Error: $DEVICE is not formatted with the fat filesystem."
-	exit -1
+	echo "Error: $DEVICE is not formatted with the fat filesystem." >&2
+	exit 1
 fi
 
 if [ ! "`grub-probe -d $DEVICE -t partmap`" == "msdos" ]; then
-	echo "Error: $MBR does not contain a MBR style partition table."
-	exit -1
+	echo "Error: $MBR does not contain a MBR style partition table." >&2
+	exit 1
 fi
 
 echo "Mounting $DEVICE to /tmp/grml-plus/mnt."

--- a/sign-uefi-for-secure-boot
+++ b/sign-uefi-for-secure-boot
@@ -5,15 +5,15 @@ set -e
 mkdir -p efi/boot
 
 if [ ! -f efi/boot/bootx64.efi ]; then
-	echo "Error: Please run ./add-uefi-support first!"
+	echo "Error: Please run ./add-uefi-support first!" >&2
 	extra_cleanup
-	exit -1
+	exit 1
 fi
 
 if [ "`dpkg --print-architecture`" != "amd64" ]; then
-	echo "Error: sbsigntools are only available for grml64!"
+	echo "Error: sbsigntools are only available for grml64!" >&2
 	extra_cleanup
-	exit -1
+	exit 1
 fi
 
 if [ -f efi/boot/grml-plus-ca.crt -a ! -f efi/boot/grubx64.efi \


### PR DESCRIPTION
'-1' is not a valid exit code, see e.g.
http://tldp.org/LDP/abs/html/exitcodes.html
