### PR TITLE
Small eror

### DIFF
--- a/make-grml-plus
+++ b/make-grml-plus
@@ -25,7 +25,7 @@ if [ ! "`grub-probe -d $DEVICE -t fs`" == "fat" ]; then
 	exit 1
 fi
 
-if [ ! "`grub-probe -d $DEVICE -t partmap`" == "msdos " ]; then
+if [ ! "`grub-probe -d $DEVICE -t partmap`" == "msdos" ]; then
 	echo "Error: $MBR does not contain a MBR style partition table." >&2
 	exit 1
 fi


### PR DESCRIPTION
changed 
if [ ! "`grub-probe -d $DEVICE -t partmap`" == "msdos " ]; then
    echo "Error: $MBR does not contain a MBR style partition table." >&2
    exit 1
fi

TO

if [ ! "`grub-probe -d $DEVICE -t partmap`" == "msdos" ]; then
    echo "Error: $MBR does not contain a MBR style partition table." >&2
    exit 1
fi
